### PR TITLE
Add prototype project dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# clubschool
-clubschool
+# Clubschool Project Dashboard Prototype
+
+This repository contains a lightweight prototype for a responsive web dashboard
+used to manage project members across the planning, design, and publishing
+groups. The dashboard shows each participant's role, allocation period, and
+utilization rate in one view.
+
+## Getting Started
+
+Open `index.html` in a browser to view the dashboard. The interface is fully
+client-side and uses static sample data defined in `app.js`.
+
+## Development
+
+- `index.html`: Main page rendering the dashboard.
+- `styles.css`: Basic responsive layout using Flexbox.
+- `app.js`: Sample data and dynamic table rendering logic.
+
+## Testing
+
+A placeholder test script is provided. Run:
+
+```bash
+npm test
+```
+
+This will output a message confirming there are currently no automated tests.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,55 @@
+const data = [
+  {
+    project: "웹 리뉴얼",
+    group: "기획그룹",
+    role: "PM",
+    period: "2024-01 ~ 2024-03",
+    utilization: "80%",
+  },
+  {
+    project: "앱 런칭",
+    group: "디자인그룹",
+    role: "디자이너",
+    period: "2024-02 ~ 2024-05",
+    utilization: "100%",
+  },
+  {
+    project: "웹 접근성 개선",
+    group: "퍼블리싱그룹",
+    role: "퍼블리셔",
+    period: "2024-03 ~ 2024-04",
+    utilization: "60%",
+  },
+];
+
+const tbody = document.querySelector("#dashboard tbody");
+
+data.forEach((item) => {
+  const tr = document.createElement("tr");
+
+  Object.entries(item).forEach(([key, value]) => {
+    const td = document.createElement("td");
+    td.textContent = value;
+    td.setAttribute("data-label", headerLabel(key));
+    tr.appendChild(td);
+  });
+
+  tbody.appendChild(tr);
+});
+
+function headerLabel(key) {
+  switch (key) {
+    case "project":
+      return "프로젝트";
+    case "group":
+      return "그룹";
+    case "role":
+      return "역할";
+    case "period":
+      return "기간";
+    case "utilization":
+      return "가동률";
+    default:
+      return key;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>프로젝트 투입 대시보드</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>프로젝트 투입 대시보드</h1>
+  </header>
+  <main>
+    <table id="dashboard">
+      <thead>
+        <tr>
+          <th>프로젝트</th>
+          <th>그룹</th>
+          <th>역할</th>
+          <th>기간</th>
+          <th>가동률</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Data rows injected by app.js -->
+      </tbody>
+    </table>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "clubschool-dashboard-prototype",
+  "version": "1.0.0",
+  "description": "Responsive project dashboard prototype",
+  "scripts": {
+    "test": "echo 'No tests specified'"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,55 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background-color: #2c3e50;
+  color: white;
+  padding: 1rem;
+  text-align: center;
+}
+
+main {
+  padding: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+th {
+  background-color: #f4f4f4;
+}
+
+/* Responsive: stack cells on small screens */
+@media (max-width: 600px) {
+  table, thead, tbody, th, td, tr {
+    display: block;
+  }
+  thead tr {
+    display: none;
+  }
+  tr {
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+  }
+  td {
+    border: none;
+    display: flex;
+    justify-content: space-between;
+  }
+  td::before {
+    content: attr(data-label);
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive dashboard with sample project allocation data
- include basic styles and client-side rendering logic
- document usage and placeholder test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe001a84c83309567dcd19b98e848