### PR TITLE
Chore: GitHub Pages 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+# master에 푸시될 때마다 앱을 빌드해 GitHub Pages로 자동 배포한다.
+# 이 방식을 쓰면 docs/를 수동으로 재빌드·커밋할 필요가 없다(회귀·누락 방지).
+# 사전 1회 설정: 저장소 Settings → Pages → Build and deployment → Source = "GitHub Actions".
+# 참고: Actions 러너에는 GITHUB_ACTIONS=true가 자동 주입되므로 vite.config.ts의
+#       base(`/clubschool/`)가 그대로 적용된다(별도 지정 불필요).
+
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: # 수동 실행 허용
+
+# GITHUB_TOKEN에 Pages 배포 권한 부여
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 동시에 한 번만 배포(중복 실행 시 최신만). 진행 중 배포는 취소하지 않음.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node 설치
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: 의존성 설치
+        run: npm ci
+
+      - name: 프로덕션 빌드
+        run: npm run build
+
+      - name: Pages 아티팩트 업로드(dist)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: GitHub Pages 배포
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 개요

`master`에 푸시될 때마다 앱을 빌드해 **GitHub Pages로 자동 배포**하는 GitHub Actions 워크플로우를 추가합니다.

## 왜

기존엔 `docs/` 정적 빌드를 **수동으로 재빌드·커밋**해야 했고, 그 과정의 누락(`globals.css`의 `@import "tailwindcss";` 유실)이 방금 배포 회귀로 이어졌습니다. Actions 배포로 전환하면 수동 빌드 단계가 사라져 이런 회귀를 근본적으로 예방합니다.

## 내용 (`.github/workflows/deploy.yml`)

- **트리거:** `push`(master) + `workflow_dispatch`(수동 실행)
- **빌드:** `npm ci` → `npm run build`. 러너의 `GITHUB_ACTIONS=true`로 `vite.config.ts`의 base(`/clubschool/`)가 자동 적용
- **배포:** `upload-pages-artifact`(dist) → `deploy-pages`
- **권한:** `pages: write`, `id-token: write`, `contents: read` / **동시성:** `pages` 그룹 1개만

## ⚠️ 병합 후 1회 설정 (필수)

이 워크플로우가 실제로 배포하려면 저장소 설정을 한 번 바꿔야 합니다:

> **Settings → Pages → Build and deployment → Source = `GitHub Actions`**

- 소스를 바꾸기 **전까지는** 기존 `master/docs` 배포가 그대로 유지되어 **다운타임이 없습니다.**
- 소스를 `GitHub Actions`로 바꾸면 이후 master 푸시마다 자동 빌드·배포됩니다.
- 전환 후 `docs/` 폴더는 배포에 쓰이지 않으므로 이후 별도 정리 가능(이 PR에서는 안전을 위해 유지).

## 검증

- 워크플로우 YAML 문법·구조 검증(트리거·권한·잡·업로드 경로 `dist`)
- 빌드 산출물 경로(`vite.config.ts` outDir=`dist`)와 업로드 경로 일치 확인
- `npm ci` 락파일 동기화(dry-run) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xjVSVmgBPTBmHkcRPvh9f

---
_Generated by [Claude Code](https://claude.ai/code/session_012xjVSVmgBPTBmHkcRPvh9f)_